### PR TITLE
Fix pedometer start logic

### DIFF
--- a/src/components/Pedometer.tsx
+++ b/src/components/Pedometer.tsx
@@ -441,7 +441,22 @@ const PedometerComponent: React.FC<PedometerProps> = ({ steps, setSteps, onTimeU
 
   // Iniciar podómetro persistente
   const startPedometer = async () => {
-    if (!pedometerAvailable) {
+    // Si aún no sabemos si el podómetro está disponible, consultarlo ahora
+    if (pedometerAvailable === null) {
+      try {
+        const available = await Pedometer.isAvailableAsync();
+        setPedometerAvailable(available);
+        if (!available) {
+          Alert.alert('Error', 'El podómetro no está disponible en este dispositivo');
+          return;
+        }
+      } catch (error) {
+        console.log('Error comprobando disponibilidad del podómetro:', error);
+        Alert.alert('Error', 'No se pudo verificar el podómetro');
+        return;
+      }
+    } else if (!pedometerAvailable) {
+      Alert.alert('Error', 'El podómetro no está disponible en este dispositivo');
       return;
     }
 


### PR DESCRIPTION
## Summary
- check pedometer availability inside `startPedometer`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find many modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843399952c883288b8f6cb4f1e8fc53