### PR TITLE
Add activity history screen

### DIFF
--- a/src/navigation/MainTabsNavigator.tsx
+++ b/src/navigation/MainTabsNavigator.tsx
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import DashboardScreen from '../screens/DashboardScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import RegisterActivityScreen from '../screens/RegisterActivityScreen';
+import ActivityHistoryScreen from '../screens/ActivityHistoryScreen';
 import WalletScreen from '../screens/WalletScreen';
 import StoreScreen from '../screens/StoreScreen';
 import LogoutScreen from '../screens/LogoutScreen';
@@ -14,6 +15,7 @@ export type TabsParamList = {
   Dashboard: undefined;
   Profile: undefined;
   RegisterActivity: undefined;
+  ActivityHistory: undefined;
   Wallet: undefined;
   Store: undefined;
   Logout: undefined;
@@ -31,6 +33,7 @@ export default function MainTabs() {
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="Profile" component={ProfileScreen} />
       <Tab.Screen name="RegisterActivity" component={RegisterActivityScreen} />
+      <Tab.Screen name="ActivityHistory" component={ActivityHistoryScreen} />
       <Tab.Screen name="Wallet" component={WalletScreen} />
       <Tab.Screen name="Store" component={StoreScreen} />
       <Tab.Screen name="Logout" component={LogoutScreen} />

--- a/src/screens/ActivityHistoryScreen.tsx
+++ b/src/screens/ActivityHistoryScreen.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, FlatList } from 'react-native';
+import api from '../services/api';
+
+interface Activity {
+  id: number;
+  exercise_type: string;
+  duration: number;
+  created_at: string;
+}
+
+export default function ActivityHistoryScreen() {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchActivities = async () => {
+      try {
+        const { data } = await api.get<{ activities: Activity[] }>('/app/activities');
+        setActivities(data.activities || data);
+      } catch (err) {
+        console.error('Error fetching activities:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchActivities();
+  }, []);
+
+  const renderItem = ({ item }: { item: Activity }) => (
+    <View style={styles.row}>
+      <Text style={styles.type}>{item.exercise_type}</Text>
+      <Text style={styles.duration}>{item.duration}</Text>
+      <Text style={styles.date}>{new Date(item.created_at).toLocaleDateString()}</Text>
+    </View>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563eb" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={activities}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  listContent: {
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  type: {
+    flex: 1,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  duration: {
+    width: 80,
+    textAlign: 'right',
+    color: '#2563eb',
+  },
+  date: {
+    width: 100,
+    textAlign: 'right',
+    color: '#6b7280',
+  },
+});


### PR DESCRIPTION
## Summary
- create an ActivityHistory screen fetching user activities
- show exercise type, duration and date in a list
- register ActivityHistory route in `MainTabsNavigator`

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684340aa46c48328bcf48b190dc4b385