### PR TITLE
Add activity history view and update weight formula

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -8,13 +8,13 @@ export default function BottomNavigation({ state, navigation }: BottomTabBarProp
   const { bottom } = useSafeAreaInsets();
 
   // Filtrar solo las rutas que queremos mostrar (sin Profile)
-  const allowedRoutes = ['Dashboard', 'RegisterActivity', 'Logout'];
+  const allowedRoutes = ['Dashboard', 'RegisterActivity', 'ActivityHistory', 'Logout'];
   const filteredRoutes = state.routes.filter(route => allowedRoutes.includes(route.name));
 
   return (
     <View style={[styles.navbar, { paddingBottom: bottom, height: 64 + bottom }]}>
-      {filteredRoutes.map((route, index) => {
-        const isActive = state.index === index;
+      {filteredRoutes.map((route) => {
+        const isActive = state.index === state.routes.indexOf(route);
 
         /* Ícono y texto según la ruta */
         type TabInfo = { icon: any; label: any; iconType: 'fontawesome' | 'fontawesome5' };
@@ -23,6 +23,8 @@ export default function BottomNavigation({ state, navigation }: BottomTabBarProp
             ? { icon: 'home', label: 'Inicio', iconType: 'fontawesome' }
             : route.name === 'RegisterActivity'
             ? { icon: 'running', label: 'Actividad', iconType: 'fontawesome5' }
+            : route.name === 'ActivityHistory'
+            ? { icon: 'history', label: 'Historial', iconType: 'fontawesome' }
             : { icon: 'sign-out', label: 'Salir', iconType: 'fontawesome' };
 
         return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -50,6 +50,8 @@ export interface Collaborator {
   photo_path: string | null;
   photo_url: string | null;
   coin_fits: number;
+  IMC_objetivo?: string;
+  peso_objetivo?: string;
   created_at: string;
   updated_at: string;
   user: User;

--- a/src/navigation/MainTabsNavigator.tsx
+++ b/src/navigation/MainTabsNavigator.tsx
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import DashboardScreen from '../screens/DashboardScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import RegisterActivityScreen from '../screens/RegisterActivityScreen';
+import ActivityHistoryScreen from '../screens/ActivityHistoryScreen';
 import WalletScreen from '../screens/WalletScreen';
 import StoreScreen from '../screens/StoreScreen';
 import LogoutScreen from '../screens/LogoutScreen';
@@ -14,6 +15,7 @@ export type TabsParamList = {
   Dashboard: undefined;
   Profile: undefined;
   RegisterActivity: undefined;
+  ActivityHistory: undefined;
   Wallet: undefined;
   Store: undefined;
   Logout: undefined;
@@ -31,6 +33,7 @@ export default function MainTabs() {
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="Profile" component={ProfileScreen} />
       <Tab.Screen name="RegisterActivity" component={RegisterActivityScreen} />
+      <Tab.Screen name="ActivityHistory" component={ActivityHistoryScreen} />
       <Tab.Screen name="Wallet" component={WalletScreen} />
       <Tab.Screen name="Store" component={StoreScreen} />
       <Tab.Screen name="Logout" component={LogoutScreen} />

--- a/src/screens/ActivityHistoryScreen.tsx
+++ b/src/screens/ActivityHistoryScreen.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { fetchUserActivities } from '../services/api';
+
+interface Activity {
+  id: number;
+  exercise_type: string;
+  duration: number;
+  duration_unit: string;
+  intensity: string;
+  calories: number | null;
+  created_at: string;
+}
+
+export default function ActivityHistoryScreen() {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchUserActivities();
+        setActivities(data);
+      } catch (error) {
+        console.error('Error fetching activities', error);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (!activities.length) {
+    return (
+      <View style={styles.centered}>
+        <Text>No hay actividades registradas.</Text>
+      </View>
+    );
+  }
+
+  const renderItem = ({ item }: { item: Activity }) => (
+    <View style={styles.item}>
+      <Text style={styles.title}>{item.exercise_type}</Text>
+      <Text style={styles.subtitle}>
+        {item.duration} {item.duration_unit} - {item.intensity}
+      </Text>
+      <Text style={styles.date}>
+        {new Date(item.created_at).toLocaleString()}
+      </Text>
+    </View>
+  );
+
+  return (
+    <FlatList
+      data={activities}
+      keyExtractor={(item) => item.id.toString()}
+      contentContainerStyle={styles.list}
+      renderItem={renderItem}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { padding: 16 },
+  item: {
+    backgroundColor: '#f3f4f6',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  title: { fontWeight: 'bold', marginBottom: 4, color: '#1f2937' },
+  subtitle: { color: '#4b5563', marginBottom: 4 },
+  date: { fontSize: 12, color: '#6b7280' },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+});

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -39,11 +39,10 @@ const COLORS = {
   danger: '#ff7875',
 };
 
-// Función para calcular peso objetivo basado en IMC saludable (21.5)
-const calculateTargetWeight = (altura: number) => {
+// Función para calcular peso objetivo basado en IMC (por defecto 24)
+const calculateTargetWeight = (altura: number, imc = 24) => {
   const alturaMetros = altura / 100;
-  const imcObjetivo = 21.5; // IMC ideal en el rango normal (18.5-24.9)
-  return Math.round(imcObjetivo * alturaMetros * alturaMetros);
+  return Math.round(imc * alturaMetros * alturaMetros);
 };
 
 // Función para convertir kg a libras
@@ -153,7 +152,12 @@ const uploadPhoto = async () => {
   // Cálculos para peso objetivo y conversiones
   const pesoActualKg = parseFloat(collaborator.peso.toString());
   const pesoActualLbs = kgToLbs(pesoActualKg);
-  const pesoObjetivoKg = calculateTargetWeight(parseFloat(collaborator.altura.toString()));
+  const imcTarget = collaborator.IMC_objetivo
+    ? parseFloat(collaborator.IMC_objetivo.toString())
+    : 24;
+  const pesoObjetivoKg = collaborator.peso_objetivo
+    ? parseFloat(collaborator.peso_objetivo.toString())
+    : calculateTargetWeight(parseFloat(collaborator.altura.toString()), imcTarget);
   const pesoObjetivoLbs = kgToLbs(pesoObjetivoKg);
   const imcStatus = getIMCStatus(parseFloat(collaborator.indice_masa_corporal.toString()));
   const diferenciaPeso = pesoActualKg - pesoObjetivoKg;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -45,4 +45,9 @@ export async function logout() {
   await AsyncStorage.multiRemove(['auth_token', 'user_data'])
 }
 
+export async function fetchUserActivities() {
+  const { data } = await api.get('/app/user/activities')
+  return data.data ?? data
+}
+
 export default api


### PR DESCRIPTION
## Summary
- include IMC_objetivo and peso_objetivo fields in Collaborator interface
- update dashboard weight calculations to use IMC 24 or backend values
- add API helper and screen to list user activities
- show history tab in navigation and bottom bar

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68434aa3fa4c8328aa0ab9b8acf639ce