### PR TITLE
Add BMI indicator bar and plan-based pedometer goals

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-native-safe-area-context": "^5.4.0",
 
     "react-native-screens": "^4.11.1",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
     "react-dom": "19.0.0",
     "react-native-web": "^0.20.0",
     "@expo/metro-runtime": "~5.0.4"

--- a/src/components/BmiScale.tsx
+++ b/src/components/BmiScale.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface BmiScaleProps {
+  bmi: number;
+}
+
+const ranges = [
+  { label: 'Bajo', color: '#fbbf24', min: 0, max: 18.4 },
+  { label: 'Normal', color: '#10b981', min: 18.5, max: 24.9 },
+  { label: 'Sobrepeso', color: '#f59e0b', min: 25, max: 29.9 },
+  { label: 'Obesidad', color: '#ef4444', min: 30, max: 40 },
+];
+
+export default function BmiScale({ bmi }: BmiScaleProps) {
+  const max = ranges[ranges.length - 1].max;
+  const percent = Math.min((bmi / max) * 100, 100);
+  return (
+    <View style={styles.container}>
+      <View style={styles.barContainer}>
+        {ranges.map((r, idx) => (
+          <View key={idx} style={[styles.segment, { backgroundColor: r.color }]} />
+        ))}
+        <View style={[styles.indicator, { left: `${percent}%` }]} />
+      </View>
+      <View style={styles.labelsContainer}>
+        {ranges.map((r, idx) => (
+          <Text key={idx} style={styles.label}>{r.label}</Text>
+        ))}
+      </View>
+      <View style={styles.valuesContainer}>
+        {ranges.map((r, idx) => (
+          <Text key={idx} style={styles.value}>{`${r.min}-${r.max}`}</Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginVertical: 16,
+  },
+  barContainer: {
+    flexDirection: 'row',
+    height: 12,
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  segment: {
+    flex: 1,
+  },
+  indicator: {
+    position: 'absolute',
+    top: -6,
+    width: 0,
+    height: 24,
+    borderLeftWidth: 2,
+    borderLeftColor: '#374151',
+  },
+  labelsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 4,
+  },
+  valuesContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontSize: 10,
+    color: '#374151',
+  },
+  value: {
+    fontSize: 10,
+    color: '#6b7280',
+  },
+});

--- a/src/components/Pedometer.tsx
+++ b/src/components/Pedometer.tsx
@@ -32,15 +32,21 @@ interface PedometerProps {
   steps: number;
   setSteps: React.Dispatch<React.SetStateAction<number>>;
   onTimeUpdate?: (seconds: number) => void;
+  dailyGoal?: number;
 }
 
-const PedometerComponent: React.FC<PedometerProps> = ({ steps, setSteps, onTimeUpdate }) => {
+const PedometerComponent: React.FC<PedometerProps> = ({ steps, setSteps, onTimeUpdate, dailyGoal }) => {
   const [pedometerAvailable, setPedometerAvailable] = useState<boolean | null>(null);
   const [isActive, setIsActive] = useState(false);
   const [permissionGranted, setPermissionGranted] = useState<boolean | null>(null);
-  const [goal] = useState(10000);
+  const [goal, setGoal] = useState(10000);
   const [strideLength] = useState(0.70);
   const [dailySteps, setDailySteps] = useState(0);
+  useEffect(() => {
+    if (dailyGoal) {
+      setGoal(dailyGoal);
+    }
+  }, [dailyGoal]);
   const [lastResetDate, setLastResetDate] = useState(new Date().toDateString());
   // Estados del temporizador mejorados
   const [elapsedTime, setElapsedTime] = useState(0);

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -18,6 +18,7 @@ import { AuthContext } from '../contexts/AuthContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { styles } from './styles/DashboardScreen.styles';
+import BmiScale from '../components/BmiScale';
 
 const { width } = Dimensions.get('window');
 
@@ -357,6 +358,8 @@ const uploadPhoto = async () => {
             </Text>
           </View>
         </View>
+
+        <BmiScale bmi={parseFloat(collaborator.indice_masa_corporal.toString())} />
 
         {/* Personal Information Card */}
         <View style={styles.infoCard}>

--- a/src/screens/RegisterActivityScreen.tsx
+++ b/src/screens/RegisterActivityScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
   SafeAreaView, View, Text, ScrollView, StyleSheet,
   TouchableOpacity, Alert, Image, TextInput, Platform,
@@ -10,6 +10,7 @@ import * as Location from 'expo-location';
 import * as FileSystem from 'expo-file-system';
 import { MaterialIcons, FontAwesome, Ionicons } from '@expo/vector-icons';
 import api from '../services/api';
+import { AuthContext } from '../contexts/AuthContext';
 
 import PedometerComponent from '../components/Pedometer';
 import { styles } from './styles/RegisterActivityScreen.styles';
@@ -25,6 +26,15 @@ export default function RegisterActivityScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [notes, setNotes] = useState('');
   const [steps, setSteps] = useState(0);
+
+  const { collaborator } = useContext(AuthContext);
+  const getStepGoal = (level: string) => {
+    if (level === 'KoalaFit') return 3000;
+    if (level === 'JaguarFit') return 6000;
+    if (level === 'HalcónFit') return 10000;
+    return 10000;
+  };
+  const stepGoal = getStepGoal(collaborator?.nivel_asignado || '');
 
 
   // Estados para modales de selección
@@ -419,6 +429,7 @@ export default function RegisterActivityScreen() {
             <PedometerComponent
               steps={steps}
               setSteps={setSteps}
+              dailyGoal={stepGoal}
             />
           </View>
           {/* 2. Sección de Calorías (separada) */}


### PR DESCRIPTION
## Summary
- introduce `BmiScale` component with range indicator
- show the BMI scale on the dashboard
- adapt `PedometerComponent` to accept a `dailyGoal` prop
- set pedometer goals based on collaborator plan
- fix malformed `package.json`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848ae54dcd88328be8860adc7035ffd