### PR TITLE
Add coin rules and team info modal

### DIFF
--- a/src/components/CoinRulesCard.tsx
+++ b/src/components/CoinRulesCard.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { styles as dashStyles, COLORS } from '../screens/styles/DashboardScreen.styles';
+
+const RULES = [
+  { icon: 'directions-walk', text: 'Completa tu meta diaria para ganar 10 CoinFits.' },
+  { icon: 'photo-camera', text: 'Sube evidencia (foto o ubicación) y recibe +2 CoinFits.' },
+  { icon: 'arrow-upward', text: 'Supera tu meta personal y obtén +3 CoinFits.' },
+  {
+    icon: 'calendar-today',
+    text: 'Cumple tus metas 5 días o más en la semana y recibe un bono de +10 CoinFits.'
+  },
+  { icon: 'block', text: 'Máximo 10 CoinFits por día.' }
+];
+
+export default function CoinRulesCard() {
+  return (
+    <View style={dashStyles.infoCard}>
+      <View style={dashStyles.cardHeader}>
+        <LinearGradient
+          colors={[COLORS.success, COLORS.lightGreen]}
+          style={dashStyles.cardIconContainer}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+        >
+          <MaterialIcons name="attach-money" size={22} color={COLORS.white} />
+        </LinearGradient>
+        <Text style={dashStyles.cardTitle}>Reglas para obtener CoinFits</Text>
+      </View>
+      {RULES.map(rule => (
+        <View key={rule.text} style={dashStyles.ruleRow}>
+          <MaterialIcons name={rule.icon as any} size={20} color={COLORS.success} style={dashStyles.ruleIcon} />
+          <Text style={[dashStyles.rowLabel, { flex: 1 }]}>{rule.text}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/components/TeamInfoModal.tsx
+++ b/src/components/TeamInfoModal.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+interface TeamInfoModalProps {
+  visible: boolean;
+  team: string;
+  onClose: () => void;
+}
+
+const TEAM_INFO: Record<string, { desc: string; items: string[] }> = {
+  KoalaFit: {
+    desc: "Ideal para quienes se inician en la actividad física y quieren adquirir hábitos saludables.",
+    items: ["3,000 pasos diarios", "20 minutos de actividad", "Hasta 10 CoinFits por día"]
+  },
+  JaguarFit: {
+    desc: "Para quienes tienen experiencia moderada y buscan un reto intermedio dentro del plan de bienestar.",
+    items: ["6,000 pasos diarios", "30 minutos de actividad", "10 CoinFits por día"]
+  },
+  HalcónFit: {
+    desc: "Pensado para personas activas que quieren desafiar su condición física al máximo.",
+    items: ["10,000 pasos diarios", "45 minutos de actividad", "10 CoinFits por día"]
+  }
+};
+
+export default function TeamInfoModal({ visible, team, onClose }: TeamInfoModalProps) {
+  const info = TEAM_INFO[team];
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <View style={styles.header}>
+            <Text style={styles.title}>{team}</Text>
+            <TouchableOpacity onPress={onClose}>
+              <MaterialIcons name="close" size={24} color="#64748b" />
+            </TouchableOpacity>
+          </View>
+          {info && (
+            <>
+              <Text style={styles.description}>{info.desc}</Text>
+              {info.items.map(item => (
+                <View key={item} style={styles.itemRow}>
+                  <MaterialIcons name="check-circle" size={20} color="#10b981" style={styles.itemIcon} />
+                  <Text style={styles.itemText}>{item}</Text>
+                </View>
+              ))}
+            </>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  content: {
+    backgroundColor: 'white',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1e293b',
+  },
+  description: {
+    fontSize: 15,
+    color: '#475569',
+    marginBottom: 12,
+    lineHeight: 20,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  itemIcon: {
+    marginRight: 8,
+    marginTop: 2,
+  },
+  itemText: {
+    fontSize: 15,
+    color: '#1e293b',
+    flex: 1,
+    lineHeight: 20,
+  },
+});

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -19,6 +19,8 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { styles } from './styles/DashboardScreen.styles';
 import BmiScale from '../components/BmiScale';
+import CoinRulesCard from '../components/CoinRulesCard';
+import TeamInfoModal from '../components/TeamInfoModal';
 
 const { width } = Dimensions.get('window');
 
@@ -73,6 +75,9 @@ export default function DashboardScreen() {
   const [confPwd, setConfPwd] = useState('');
   const [changing, setChanging] = useState(false);
   const [showPasswordForm, setShowPasswordForm] = useState(false);
+
+  const [showTeamInfo, setShowTeamInfo] = useState(false);
+  const [selectedTeam, setSelectedTeam] = useState('');
 
   // Picker de galería
   const pickImage = async () => {
@@ -361,6 +366,8 @@ const uploadPhoto = async () => {
 
         <BmiScale bmi={parseFloat(collaborator.indice_masa_corporal.toString())} />
 
+        <CoinRulesCard />
+
         {/* Personal Information Card */}
         <View style={styles.infoCard}>
           <View style={styles.cardHeader}>
@@ -488,7 +495,18 @@ const uploadPhoto = async () => {
             >
               <MaterialIcons name="fitness-center" size={22} color={COLORS.white} />
             </LinearGradient>
-            <Text style={styles.cardTitle}>Plan de Bienestar: {collaborator.nivel_asignado}</Text>
+            <Text style={styles.cardTitle}>
+              Plan de Bienestar:
+              <Text
+                style={styles.teamLink}
+                onPress={() => {
+                  setSelectedTeam(collaborator.nivel_asignado);
+                  setShowTeamInfo(true);
+                }}
+              >
+                {' '}{collaborator.nivel_asignado}
+              </Text>
+            </Text>
           </View>
 
           <View style={styles.levelDetails}>
@@ -529,6 +547,11 @@ const uploadPhoto = async () => {
           </Text>
         </View>
       </ScrollView>
+      <TeamInfoModal
+        visible={showTeamInfo}
+        team={selectedTeam}
+        onClose={() => setShowTeamInfo(false)}
+      />
     </View>
   );
 }

--- a/src/screens/styles/DashboardScreen.styles.ts
+++ b/src/screens/styles/DashboardScreen.styles.ts
@@ -394,6 +394,11 @@ export const styles = StyleSheet.create({
     flex: 1,
     lineHeight: 20,
   },
+  teamLink: {
+    color: COLORS.success,
+    fontWeight: '700',
+    textDecorationLine: 'underline',
+  },
 
   // === INFO ROWS ===
   infoRow: {
@@ -438,6 +443,17 @@ export const styles = StyleSheet.create({
     color: COLORS.accent,
     fontSize: 14,
     fontWeight: '700',
+  },
+
+  // === RULES LIST ===
+  ruleRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  ruleIcon: {
+    marginRight: 8,
+    marginTop: 2,
   },
 
   // === LEVEL CARD ===


### PR DESCRIPTION
## Summary
- add `CoinRulesCard` component with rules for earning CoinFits
- create `TeamInfoModal` for KoalaFit, JaguarFit and HalcónFit info
- show the new card and modal on the dashboard
- allow tapping on team name to open the modal
- tweak dashboard styles for clickable team link
- improve design of the rules card and team modal

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685213bd687c8328a834b1cba577d856