### PR TITLE
Fix pedometer restarting on resume

### DIFF
--- a/src/components/Pedometer.tsx
+++ b/src/components/Pedometer.tsx
@@ -400,6 +400,12 @@ const PedometerComponent: React.FC<PedometerProps> = ({ steps, setSteps, onTimeU
           calculateElapsedTime();
           // Reiniciar timer de UI
           startUITimer();
+          // Verificar si el podómetro sigue activo, si no, reiniciarlo
+          if (!subscriptionRef.current) {
+            startPedometer();
+          }
+          // Asegurar que la tarea en background esté registrada
+          setupBackgroundFetch();
         }
       } else if (nextAppState.match(/inactive|background/)) {
         // App va al fondo


### PR DESCRIPTION
## Summary
- restart pedometer and background task if app resumes while pedometer is active
- ensure file ends with newline

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685429eff29483289a415370647c4756