### PR TITLE
Add notification and info modules

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -8,7 +8,15 @@ export default function BottomNavigation({ state, navigation }: BottomTabBarProp
   const { bottom } = useSafeAreaInsets();
 
   // Filtrar solo las rutas que queremos mostrar (sin Profile)
-  const allowedRoutes = ['Dashboard', 'RegisterActivity', 'ReferenceActivity','ActivityHistory', 'Logout'];
+  const allowedRoutes = [
+    'Dashboard',
+    'RegisterActivity',
+    'ReferenceActivity',
+    'ActivityHistory',
+    'Notifications',
+    'GeneralInfo',
+    'Logout',
+  ];
   const filteredRoutes = state.routes.filter(route => allowedRoutes.includes(route.name));
 
   return (
@@ -24,6 +32,8 @@ export default function BottomNavigation({ state, navigation }: BottomTabBarProp
           RegisterActivity: { icon: 'running', label: 'Actividad', iconType: 'fontawesome5' },
           ActivityHistory: { icon: 'history', label: 'Historial', iconType: 'fontawesome' },
           ReferenceActivity: { icon: 'info-circle', label: 'Referencias', iconType: 'fontawesome5' },
+          Notifications: { icon: 'bell', label: 'Avisos', iconType: 'fontawesome' },
+          GeneralInfo: { icon: 'lightbulb-o', label: 'Info', iconType: 'fontawesome' },
           Logout: { icon: 'sign-out', label: 'Salir', iconType: 'fontawesome' },
         };
 

--- a/src/navigation/MainTabsNavigator.tsx
+++ b/src/navigation/MainTabsNavigator.tsx
@@ -7,6 +7,8 @@ import RegisterActivityScreen from '../screens/RegisterActivityScreen';
 import ActivityHistoryScreen from '../screens/ActivityHistoryScreen';
 import WalletScreen from '../screens/WalletScreen';
 import StoreScreen from '../screens/StoreScreen';
+import NotificationsScreen from '../screens/NotificationsScreen';
+import GeneralInfoScreen from '../screens/GeneralInfoScreen';
 import LogoutScreen from '../screens/LogoutScreen';
 
 import BottomNavigation from '../components/BottomNavigation';
@@ -20,6 +22,8 @@ export type TabsParamList = {
   ReferenceActivity: undefined;
   Wallet: undefined;
   Store: undefined;
+  Notifications: undefined;
+  GeneralInfo: undefined;
   Logout: undefined;
 };
 
@@ -27,7 +31,7 @@ const Tab = createBottomTabNavigator<TabsParamList>();
 
 export default function MainTabs() {
   return (
-    <Tab.Navigator
+  <Tab.Navigator
       screenOptions={{ headerShown: false }}
       tabBar={(props) => <BottomNavigation {...props} />}
     >
@@ -39,6 +43,8 @@ export default function MainTabs() {
       <Tab.Screen name="ReferenceActivity" component={ReferenceActivityScreen} />
       <Tab.Screen name="Wallet" component={WalletScreen} />
       <Tab.Screen name="Store" component={StoreScreen} />
+      <Tab.Screen name="Notifications" component={NotificationsScreen} />
+      <Tab.Screen name="GeneralInfo" component={GeneralInfoScreen} />
       <Tab.Screen name="Logout" component={LogoutScreen} />
     </Tab.Navigator>
   );

--- a/src/screens/GeneralInfoScreen.tsx
+++ b/src/screens/GeneralInfoScreen.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react'
+import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native'
+import { fetchGeneralInfo } from '../services/api'
+
+interface InfoItem {
+  id: number
+  title: string
+  content: string
+  created_at: string
+}
+
+export default function GeneralInfoScreen() {
+  const [items, setItems] = useState<InfoItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchGeneralInfo<InfoItem>()
+        setItems(data)
+      } catch (err) {
+        console.error('Error loading general info', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <View style={styles.center}>
+        <Text>No hay información disponible</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={items}
+        keyExtractor={i => i.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.title}>{item.title}</Text>
+            <Text style={styles.content}>{item.content}</Text>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  item: { marginBottom: 16 },
+  title: { fontWeight: 'bold', color: '#1e293b', marginBottom: 4 },
+  content: { color: '#475569' },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+})

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react'
+import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native'
+import { fetchNotifications } from '../services/api'
+
+interface Notification {
+  id: number
+  title: string
+  body: string
+  created_at: string
+}
+
+export default function NotificationsScreen() {
+  const [items, setItems] = useState<Notification[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchNotifications<Notification>()
+        setItems(data)
+      } catch (err) {
+        console.error('Error loading notifications', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <View style={styles.center}>
+        <Text>No hay notificaciones</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={items}
+        keyExtractor={i => i.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.title}>{item.title}</Text>
+            <Text style={styles.body}>{item.body}</Text>
+            <Text style={styles.date}>{new Date(item.created_at).toLocaleDateString()}</Text>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  item: { marginBottom: 16 },
+  title: { fontWeight: 'bold', color: '#1e293b', marginBottom: 4 },
+  body: { color: '#475569' },
+  date: { color: '#64748b', fontSize: 12, marginTop: 4 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+})

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -71,4 +71,14 @@ export async function fetchUserActivities<T>(page = 1): Promise<ActivityPage<T>>
   }
 }
 
+export async function fetchNotifications<T>(): Promise<T[]> {
+  const { data } = await api.get('/app/notifications')
+  return Array.isArray(data) ? data : data.data ?? []
+}
+
+export async function fetchGeneralInfo<T>(): Promise<T[]> {
+  const { data } = await api.get('/app/general-info')
+  return Array.isArray(data) ? data : data.data ?? []
+}
+
 export default api


### PR DESCRIPTION
## Summary
- add API helpers for notifications and general info
- create screens to display notifications and general information
- show new screens in the bottom navigation and tabs

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68557d074e488328ae830b7f0242572b