### PR TITLE
Add quick access to notifications and info module

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,11 +5,15 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { AuthContext } from '../contexts/AuthContext';
 
 import LoginScreen from '../screens/LoginScreen';
-import MainTabs    from './MainTabsNavigator';
+import MainTabs from './MainTabsNavigator';
+import NotificationsScreen from '../screens/NotificationsScreen';
+import GeneralInfoScreen from '../screens/GeneralInfoScreen';
 
 export type RootStackParamList = {
   Login: undefined;
-  Main:  undefined;
+  Main: undefined;
+  Notifications: undefined;
+  GeneralInfo: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -26,7 +30,11 @@ export default function AppNavigator() {
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         {user ? (
-          <Stack.Screen name="Main" component={MainTabs} />
+          <>
+            <Stack.Screen name="Main" component={MainTabs} />
+            <Stack.Screen name="Notifications" component={NotificationsScreen} />
+            <Stack.Screen name="GeneralInfo" component={GeneralInfoScreen} />
+          </>
         ) : (
           <Stack.Screen name="Login" component={LoginScreen} />
         )}

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -17,6 +17,9 @@ import * as ImagePicker from 'expo-image-picker';
 import { AuthContext } from '../contexts/AuthContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../navigation/AppNavigator';
 import { styles } from './styles/DashboardScreen.styles';
 import BmiScale from '../components/BmiScale';
 import CoinRulesCard from '../components/CoinRulesCard';
@@ -64,6 +67,7 @@ const getIMCStatus = (imc: number) => {
 export default function DashboardScreen() {
   const { collaborator, refreshData, loading, updatePhoto, changePassword } = useContext(AuthContext);
   const { bottom } = useSafeAreaInsets();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   // Estado para la foto
   const [localPhotoUri, setLocalPhotoUri] = useState<string | null>(null);
@@ -191,7 +195,7 @@ const uploadPhoto = async () => {
             <Text style={styles.brandSubtext}>Sistema de Bienestar</Text>
           </View>
 
-          {/* Contenedor para CoinFits y Reload */}
+          {/* Contenedor para CoinFits y acciones */}
           <View style={styles.rightSection}>
             {/* Sección CoinFits */}
             <TouchableOpacity
@@ -201,6 +205,24 @@ const uploadPhoto = async () => {
               <FontAwesome5 name="coins" size={12} color={COLORS.gold} />
               <Text style={styles.coinValue}>{collaborator.coin_fits}</Text>
               <Text style={styles.coinLabel}>CF</Text>
+            </TouchableOpacity>
+
+            {/* Notificaciones */}
+            <TouchableOpacity
+              style={styles.headerIconButton}
+              onPress={() => navigation.navigate('Notifications')}
+              activeOpacity={0.7}
+            >
+              <FontAwesome5 name="bell" size={14} color={COLORS.white} />
+            </TouchableOpacity>
+
+            {/* Información general */}
+            <TouchableOpacity
+              style={styles.headerIconButton}
+              onPress={() => navigation.navigate('GeneralInfo')}
+              activeOpacity={0.7}
+            >
+              <FontAwesome5 name="lightbulb" size={14} color={COLORS.white} />
             </TouchableOpacity>
 
             {/* Sección Reload */}

--- a/src/screens/GeneralInfoScreen.tsx
+++ b/src/screens/GeneralInfoScreen.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+  Platform,
+} from 'react-native';
+import { FontAwesome5 } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { fetchGeneralInfo, GeneralInfoItem } from '../services/api';
+import { COLORS } from './styles/DashboardScreen.styles';
+
+export default function GeneralInfoScreen() {
+  const [items, setItems] = useState<GeneralInfoItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchGeneralInfo();
+        setItems(data);
+      } catch (err) {
+        console.error('Error loading general info', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={navigation.goBack}
+          activeOpacity={0.7}
+        >
+          <FontAwesome5 name="arrow-left" size={16} color={COLORS.white} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Información General</Text>
+      </View>
+      <FlatList
+        data={items}
+        contentContainerStyle={styles.list}
+        keyExtractor={item => String(item.id)}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={styles.item}
+            onPress={() => Alert.alert(item.title, item.content)}
+            activeOpacity={0.8}
+          >
+            <View style={styles.iconWrapper}>
+              <FontAwesome5 name="lightbulb" size={16} color={COLORS.white} />
+            </View>
+            <View style={styles.itemContent}>
+              <Text style={styles.title}>{item.title}</Text>
+              <Text style={styles.body}>{item.content}</Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: COLORS.lightGray },
+  header: {
+    backgroundColor: COLORS.primary,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOpacity: 0.1, shadowOffset: { width: 0, height: 2 }, shadowRadius: 6 },
+      android: { elevation: 3 },
+    }),
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.15)',
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    color: COLORS.white,
+    fontSize: 18,
+    fontWeight: '700',
+    marginRight: 40,
+  },
+  list: { padding: 16 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: COLORS.white,
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOpacity: 0.05, shadowOffset: { width: 0, height: 2 }, shadowRadius: 4 },
+      android: { elevation: 1 },
+    }),
+  },
+  iconWrapper: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: COLORS.secondary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  itemContent: { flex: 1 },
+  title: { fontSize: 15, fontWeight: '700', color: COLORS.darkGray },
+  body: { fontSize: 13, color: COLORS.darkGray, marginTop: 4 },
+});

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+  Platform,
+} from 'react-native';
+import { FontAwesome5 } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import {
+  fetchNotifications,
+  NotificationItem,
+  markNotificationAsRead,
+} from '../services/api';
+import { COLORS } from './styles/DashboardScreen.styles';
+
+export default function NotificationsScreen() {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchNotifications();
+        setItems(data);
+      } catch (err) {
+        console.error('Error loading notifications', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={navigation.goBack}
+          activeOpacity={0.7}
+        >
+          <FontAwesome5 name="arrow-left" size={16} color={COLORS.white} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Notificaciones</Text>
+      </View>
+      <FlatList
+        data={items}
+        contentContainerStyle={styles.list}
+        keyExtractor={item => String(item.id)}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[
+              styles.item,
+              item.read_at ? null : styles.unreadItem,
+            ]}
+            onPress={async () => {
+              Alert.alert(item.title, item.body)
+              if (!item.read_at) {
+                try {
+                  await markNotificationAsRead(item.id)
+                  setItems(prev =>
+                    prev.map(n =>
+                      n.id === item.id ? { ...n, read_at: new Date().toISOString() } : n,
+                    ),
+                  )
+                } catch (err) {
+                  console.error('Error marking notification as read', err)
+                }
+              }
+            }}
+            activeOpacity={0.8}
+          >
+            <View style={styles.iconWrapper}>
+              <FontAwesome5 name="bell" size={16} color={COLORS.white} />
+            </View>
+            <View style={styles.itemContent}>
+              <Text style={styles.title}>{item.title}</Text>
+              <Text style={styles.body}>{item.body}</Text>
+              <Text style={styles.date}>
+                {new Date(item.created_at).toLocaleDateString()}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: COLORS.lightGray },
+  header: {
+    backgroundColor: COLORS.primary,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOpacity: 0.1, shadowOffset: { width: 0, height: 2 }, shadowRadius: 6 },
+      android: { elevation: 3 },
+    }),
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.15)',
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    color: COLORS.white,
+    fontSize: 18,
+    fontWeight: '700',
+    marginRight: 40,
+  },
+  list: { padding: 16 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: COLORS.white,
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOpacity: 0.05, shadowOffset: { width: 0, height: 2 }, shadowRadius: 4 },
+      android: { elevation: 1 },
+    }),
+  },
+  unreadItem: {
+    backgroundColor: '#eaf6ff',
+  },
+  iconWrapper: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: COLORS.accent,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  itemContent: { flex: 1 },
+  title: { fontSize: 15, fontWeight: '700', color: COLORS.darkGray },
+  body: { fontSize: 13, color: COLORS.darkGray, marginTop: 4 },
+  date: { fontSize: 11, color: COLORS.mediumGray, marginTop: 6 },
+});

--- a/src/screens/styles/DashboardScreen.styles.ts
+++ b/src/screens/styles/DashboardScreen.styles.ts
@@ -177,6 +177,16 @@ export const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.3)',
   },
+  headerIconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+  },
 
   // === PASSWORD FORM ===
   passwordForm: {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -71,4 +71,32 @@ export async function fetchUserActivities<T>(page = 1): Promise<ActivityPage<T>>
   }
 }
 
+export interface NotificationItem {
+  id: number
+  title: string
+  body: string
+  created_at: string
+  read_at?: string | null
+}
+
+export async function fetchNotifications(): Promise<NotificationItem[]> {
+  const { data } = await api.get('/app/notifications')
+  return data.data ?? data
+}
+
+export async function markNotificationAsRead(id: number): Promise<void> {
+  await api.post(`/app/notifications/${id}/read`)
+}
+
+export interface GeneralInfoItem {
+  id: number
+  title: string
+  content: string
+}
+
+export async function fetchGeneralInfo(): Promise<GeneralInfoItem[]> {
+  const { data } = await api.get('/app/general-info')
+  return data.data ?? data
+}
+
 export default api


### PR DESCRIPTION
## Summary
- implement API helpers for notifications and general info
- create `NotificationsScreen` and `GeneralInfoScreen`
- expose the new screens in `AppNavigator`
- add navigation shortcuts (bell and lightbulb) in dashboard header
- style header icon button
- polish notification and info screens with modern card design
- mark notifications as read when opened

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68557fbd28e48328baebc281da027e30