### PR TITLE
Handle unread notifications

### DIFF
--- a/src/screens/ActivityHistoryScreen.tsx
+++ b/src/screens/ActivityHistoryScreen.tsx
@@ -11,6 +11,7 @@ import {
   TouchableOpacity,
 } from 'react-native'
 import { useIsFocused } from '@react-navigation/native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { MaterialIcons } from '@expo/vector-icons'
 import { fetchUserActivities } from '../services/api'
 import { exerciseIconMap } from '../constants/exerciseIcons'
@@ -40,6 +41,7 @@ export default function ActivityHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
   const isFocused = useIsFocused()
+  const { top } = useSafeAreaInsets()
 
   const loadActivities = useCallback(
     async (p: number, append = false) => {
@@ -150,7 +152,7 @@ export default function ActivityHistoryScreen() {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: top }] }>
         <View style={styles.headerContent}>
           <MaterialIcons name="history" size={24} color="white" />
           <Text style={styles.headerTitle}>Historial de Actividades</Text>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -17,10 +17,11 @@ import * as ImagePicker from 'expo-image-picker';
 import { AuthContext } from '../contexts/AuthContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import { styles } from './styles/DashboardScreen.styles';
+import { fetchNotifications } from '../services/api';
 import BmiScale from '../components/BmiScale';
 import CoinRulesCard from '../components/CoinRulesCard';
 import TeamInfoModal from '../components/TeamInfoModal';
@@ -82,6 +83,17 @@ export default function DashboardScreen() {
 
   const [showTeamInfo, setShowTeamInfo] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState('');
+
+  const [hasUnread, setHasUnread] = useState(false);
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (isFocused) {
+      fetchNotifications()
+        .then(n => setHasUnread(n.some(item => !item.read_at)))
+        .catch(err => console.error('Error fetching notifications', err));
+    }
+  }, [isFocused]);
 
   // Picker de galería
   const pickImage = async () => {
@@ -213,11 +225,12 @@ const uploadPhoto = async () => {
 
             {/* Notificaciones */}
             <TouchableOpacity
-              style={styles.headerIconButton}
+              style={[styles.headerIconButton, { position: 'relative' }]}
               onPress={() => navigation.navigate('Notifications')}
               activeOpacity={0.7}
             >
               <FontAwesome5 name="bell" size={14} color={COLORS.white} />
+              {hasUnread && <View style={styles.notificationDot} />}
             </TouchableOpacity>
 
             {/* Información general */}

--- a/src/screens/GeneralInfoScreen.tsx
+++ b/src/screens/GeneralInfoScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { Video, ResizeMode } from 'expo-av';
 import { FontAwesome5 } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fetchGeneralInfo, GeneralInfoItem } from '../services/api';
 import { COLORS } from './styles/DashboardScreen.styles';
 
@@ -22,6 +23,7 @@ export default function GeneralInfoScreen() {
   const [loading, setLoading] = useState(true);
   const [selectedItem, setSelectedItem] = useState<GeneralInfoItem | null>(null);
   const navigation = useNavigation();
+  const { top } = useSafeAreaInsets();
 
   useEffect(() => {
     const load = async () => {
@@ -47,7 +49,7 @@ export default function GeneralInfoScreen() {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: top }] }>
         <TouchableOpacity
           style={styles.backButton}
           onPress={navigation.goBack}

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -12,10 +12,12 @@ import {
 } from 'react-native';
 import { FontAwesome5 } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   fetchNotifications,
   NotificationItem,
   markNotificationAsRead,
+  deleteNotification,
 } from '../services/api';
 import { COLORS } from './styles/DashboardScreen.styles';
 
@@ -25,6 +27,7 @@ export default function NotificationsScreen() {
   const [loading, setLoading] = useState(true);
 
   const navigation = useNavigation();
+  const { top } = useSafeAreaInsets();
 
 
   useEffect(() => {
@@ -54,7 +57,7 @@ export default function NotificationsScreen() {
   return (
     <View style={styles.container}>
 
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: top }] }>
         <TouchableOpacity
           style={styles.backButton}
           onPress={navigation.goBack}
@@ -63,6 +66,21 @@ export default function NotificationsScreen() {
           <FontAwesome5 name="arrow-left" size={16} color={COLORS.white} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>Notificaciones</Text>
+        <TouchableOpacity
+          style={styles.clearButton}
+          onPress={async () => {
+            const toRemove = items.filter(i => i.read_at)
+            try {
+              await Promise.all(toRemove.map(n => deleteNotification(n.id)))
+              setItems(prev => prev.filter(n => !n.read_at))
+            } catch (err) {
+              console.error('Error removing notifications', err)
+            }
+          }}
+          activeOpacity={0.7}
+        >
+          <FontAwesome5 name="trash" size={16} color={COLORS.white} />
+        </TouchableOpacity>
       </View>
       <FlatList
         data={items}
@@ -130,13 +148,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: 'rgba(255,255,255,0.15)',
   },
+  clearButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    marginLeft: 8,
+  },
   headerTitle: {
     flex: 1,
     textAlign: 'center',
     color: COLORS.white,
     fontSize: 18,
     fontWeight: '700',
-    marginRight: 40,
+    marginRight: 0,
   },
   list: { padding: 16 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },

--- a/src/screens/RegisterActivityScreen.tsx
+++ b/src/screens/RegisterActivityScreen.tsx
@@ -14,6 +14,7 @@ import { AuthContext } from '../contexts/AuthContext';
 
 import PedometerComponent from '../components/Pedometer';
 import { styles } from './styles/RegisterActivityScreen.styles';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function RegisterActivityScreen() {
   const [exerciseType, setExerciseType] = useState('Caminata');
@@ -28,6 +29,8 @@ export default function RegisterActivityScreen() {
   const [steps, setSteps] = useState(0);
   const [surfaceType, setSurfaceType] = useState('');
   const [difficultyLevel, setDifficultyLevel] = useState('');
+
+  const { top } = useSafeAreaInsets();
 
   const { collaborator } = useContext(AuthContext);
   const getStepGoal = (level: string) => {
@@ -317,7 +320,7 @@ export default function RegisterActivityScreen() {
         style={{ flex: 1 }}
       >
         {/* Header mejorado */}
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: top }] }>
           <View style={styles.headerContent}>
             <MaterialIcons name="fitness-center" size={24} color="white" />
             <Text style={styles.headerTitle}>Registrar Actividad</Text>

--- a/src/screens/styles/DashboardScreen.styles.ts
+++ b/src/screens/styles/DashboardScreen.styles.ts
@@ -189,6 +189,17 @@ export const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.3)',
   },
+  notificationDot: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#dc2626',
+    borderWidth: 1,
+    borderColor: COLORS.white,
+  },
 
   // === PASSWORD FORM ===
   passwordForm: {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -78,17 +78,31 @@ export interface NotificationItem {
   created_at: string
 
   read_at?: string | null
+  action?: string
 
 }
 
 export async function fetchNotifications(): Promise<NotificationItem[]> {
   const { data } = await api.get('/app/notifications')
-  return data.data ?? data
+  const items = data.data ?? data
+
+  return items.map((n: any) => ({
+    id: n.id,
+    title: n.data?.title ?? '',
+    body: n.data?.body ?? '',
+    action: n.data?.action ?? '',
+    created_at: n.created_at,
+    read_at: n.read_at,
+  }))
 }
 
 
 export async function markNotificationAsRead(id: number): Promise<void> {
   await api.post(`/app/notifications/${id}/read`)
+}
+
+export async function deleteNotification(id: number): Promise<void> {
+  await api.delete(`/app/notifications/${id}`)
 }
 
 


### PR DESCRIPTION
## Summary
- decode notification JSON from server response
- allow trashing read notifications in the notifications list
- show a red dot when there are unread notifications
- pad headers with the safe area on several screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ed93eb5f483289aa766b08a160bc8